### PR TITLE
[BUGFIX] TYPO3 11.5 - Fix LogWriter when error happens before typo3 is booted

### DIFF
--- a/Classes/Service/Database/ConnectionService.php
+++ b/Classes/Service/Database/ConnectionService.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RD\ErrorLog\Service\Database;
+
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Driver\Middleware as DriverMiddleware;
+use Doctrine\DBAL\DriverManager;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Driver\PDOMySql\Driver as PDOMySqlDriver;
+use TYPO3\CMS\Core\Database\Driver\PDOPgSql\Driver as PDOPgSqlDriver;
+use TYPO3\CMS\Core\Database\Driver\PDOSqlite\Driver as PDOSqliteDriver;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * @internal
+ *
+ * This class is based on the methods taken from TYPO3\CMS\Core\Database\ConnectionPool
+ *
+ * The need for existing of this class is just one:
+ *  - when any error happens before TYPO3 is booted completely, for example, something happens during the cache flush,
+ *    it is going to be reported by our LogWriter. However, as TYPO3 is not ready at that moment, we should avoid ConnectionPool usage,
+ *    as that is deprecated since #94979
+ *    https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Deprecation-94979-UsingCacheManagerOrDatabaseConnectionsDuringTYPO3Bootstrap.html
+ *    Thus we replicate here it's functionality to create DB connection and execute SQL INSERT query "as raw as possible".
+ */
+final class ConnectionService
+{
+    private static $driverMap = [
+        'pdo_mysql' => PDOMySqlDriver::class,
+        'pdo_sqlite' => PDOSqliteDriver::class,
+        'pdo_pgsql' => PDOPgSqlDriver::class,
+    ];
+
+    /**
+     * @internal
+     *
+     * @param string $tableName
+     *
+     * @return Connection|null
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function getConnectionForTable(string $tableName): ?Connection
+    {
+        $connectionName = ConnectionPool::DEFAULT_CONNECTION_NAME;
+        if (! empty($GLOBALS['TYPO3_CONF_VARS']['DB']['TableMapping'][$tableName])) {
+            $connectionName = (string) $GLOBALS['TYPO3_CONF_VARS']['DB']['TableMapping'][$tableName];
+        }
+
+        if (empty($connectionName)) {
+            return null;
+        }
+
+        $connectionParams = $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][$connectionName] ?? [];
+        if (empty($connectionParams)) {
+            return null;
+        }
+
+        if (empty($connectionParams['wrapperClass'])) {
+            $connectionParams['wrapperClass'] = Connection::class;
+        }
+
+        if (! is_a($connectionParams['wrapperClass'], Connection::class, true)) {
+            return null;
+        }
+
+        // Transform TYPO3 `tableoptions` to valid `doctrine/dbal` connection param option `defaultTableOptions`
+        if (isset($connectionParams['tableoptions'])) {
+            $connectionParams['defaultTableOptions'] = array_replace(
+                $connectionParams['defaultTableOptions'] ?? [],
+                $connectionParams['tableoptions']
+            );
+            unset($connectionParams['tableoptions']);
+        }
+
+        // Default to UTF-8 connection charset
+        if (empty($connectionParams['charset'])) {
+            $connectionParams['charset'] = 'utf8';
+        }
+
+        // if no custom driver is provided, map TYPO3 specific drivers
+        if (! isset($connectionParams['driverClass']) && isset(self::$driverMap[$connectionParams['driver']])) {
+            $connectionParams['driverClass'] = self::$driverMap[$connectionParams['driver']];
+        }
+
+        $middlewares = $this->getDriverMiddlewares($connectionParams);
+        $configuration = $middlewares ? (new Configuration())->setMiddlewares($middlewares) : null;
+
+        /** @var Connection $connection */
+        $connection = DriverManager::getConnection($connectionParams, $configuration);
+        $connection->prepareConnection($connectionParams['initCommands'] ?? '');
+        return $connection;
+    }
+
+    private function getDriverMiddlewares(array $connectionParams): array
+    {
+        $middlewares = [];
+
+        foreach ($connectionParams['driverMiddlewares'] ?? [] as $className) {
+            if (! in_array(DriverMiddleware::class, class_implements($className) ?: [], true)) {
+                continue;
+            }
+            $middlewares[] = GeneralUtility::makeInstance($className);
+        }
+
+        return $middlewares;
+    }
+}

--- a/Classes/Service/LogWriter.php
+++ b/Classes/Service/LogWriter.php
@@ -7,6 +7,7 @@ namespace RD\ErrorLog\Service;
 use RD\ErrorLog\Domain\Model\Error;
 use RD\ErrorLog\Domain\Event\ErrorEvent;
 use RD\ErrorLog\Domain\Repository\ErrorRepository;
+use RD\ErrorLog\Service\Database\ConnectionService;
 use TYPO3\CMS\Backend\FrontendBackendUserAuthentication;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -96,8 +97,65 @@ class LogWriter implements SingletonInterface
     public function writeError(\Throwable $exception, string $channel = self::CONTEXT_WEB): void
     {
         $errorValues = $this->collectInformationForEvent($exception, $channel);
-        $errorValues['uid'] = $this->write($errorValues);
-        $this->dispatchErrorEvent($errorValues);
+
+        // if TYPO3 is in completely booted state we can use TYPO3 API as normal
+        if (GeneralUtility::getContainer()->get('boot.state')->complete) {
+            $errorValues['uid'] = $this->write($errorValues);
+            $this->dispatchErrorEvent($errorValues);
+        } else {
+            // if error happen too early the only thing we can do is to report it directly into the database "as raw as possible"
+            try {
+                $this->writeAsRawAsPossible($errorValues);
+            } catch (\Throwable $e) {
+                // no need to catch it, just silently exit
+            }
+        }
+    }
+
+    /**
+     * Avoid ConnectionPool usage prior boot completion, as that is deprecated since #94979
+     * https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Deprecation-94979-UsingCacheManagerOrDatabaseConnectionsDuringTYPO3Bootstrap.html
+     *
+     * @param array $errorValues
+     */
+    private function writeAsRawAsPossible(array $errorValues): void
+    {
+        $connection = (new ConnectionService())->getConnectionForTable('tx_errorlog_domain_model_error');
+        $errorValues = $this->prepareErrorValuesForRawQuery($errorValues);
+        $fields = implode(', ', array_keys($errorValues));
+        $values = implode(', ', array_values($errorValues));
+        $connection->executeStatement(
+            "INSERT INTO tx_errorlog_domain_model_error (" . $fields . ") VALUES (" . $values . ")"
+        );
+        $connection->close();
+    }
+
+    private function prepareErrorValuesForRawQuery(array $errorValues): array
+    {
+        // filter array only by allowed items
+        $errorValues = array_intersect_key($errorValues, array_flip([
+            'message',
+            'code',
+            'file',
+            'line',
+            'trace',
+            'browser_info',
+            'server_name',
+            'request_uri',
+            'root_page_uid',
+            'crdate',
+            'IP',
+            'user',
+            'user_id',
+            'workspace',
+            'event_dispatched',
+        ]));
+
+        foreach ($errorValues as $key => $value) {
+            $errorValues[$key] = '\'' . addslashes((string) $value) . '\'';
+        }
+
+        return $errorValues;
     }
 
     private function dispatchErrorEvent(array $errorValues): void

--- a/Classes/Service/LogWriter.php
+++ b/Classes/Service/LogWriter.php
@@ -59,7 +59,7 @@ class LogWriter implements SingletonInterface
         }
         $errorValues = [
             'data' => empty($data) ? '' : serialize($data),
-            'page_uid' => isset($GLOBALS['TSFE']) ? (int) $GLOBALS['TSFE']->id : 0,
+            'page_uid' => isset($GLOBALS['TSFE']) ? (int) $GLOBALS['TSFE']->id ?? 0 : 0,
             'message' => $exception->getMessage() ?? '',
             'code' => $exception->getCode() ?? 0,
             'file' => $file ?? '',
@@ -68,10 +68,10 @@ class LogWriter implements SingletonInterface
             'browser_info' => $_SERVER['HTTP_USER_AGENT'] ?? '',
             'server_name' => $_SERVER['SERVER_NAME'] ?? '',
             'request_uri' => $_SERVER['REQUEST_URI'] ?? '',
-            'root_page_uid' => isset($GLOBALS['TSFE']) ? $GLOBALS['TSFE']->rootLine[0]['uid'] : 0,
+            'root_page_uid' => isset($GLOBALS['TSFE']) ? $GLOBALS['TSFE']->rootLine[0]['uid'] ?? 0 : 0,
             'crdate' => $GLOBALS['EXEC_TIME'] ?? time(),
             'IP' => (string) GeneralUtility::getIndpEnv('REMOTE_ADDR') ?? '',
-            'user' =>  isset($GLOBALS['BE_USER']) ? $GLOBALS['BE_USER']->user['username'] : '',
+            'user' =>  $backendUser ? $backendUser->user['username'] ?? '' : '',
             'user_id' => $userId ?? 0,
             'workspace' => $workspace ?? 0,
             'event_dispatched' => 0,


### PR DESCRIPTION
# Description

This PR applies the following important fixes:

- fix PHP Warning when tries to access array item which doesn't exist:
<img width="553" alt="image" src="https://github.com/user-attachments/assets/edcfe136-1cc8-4c38-8798-8ef1c42d358f">

- fix PHP Error when trying to use ConnectionPool before TYPO3 is ready (booted). This is usually caused when cache clearing command is running and some deprecated code is used in ext_localconf.php or ext_tables.php files, but not only:
<img width="605" alt="image" src="https://github.com/user-attachments/assets/73c2a421-86aa-4752-bbfa-c2cb31892cf2">


NOT TESTED on TYPO3 11.5 however tested on TYPO3 12.4

The same PR was created for TYPO3 12.4 - https://github.com/raccoondepot/error_log/pull/3